### PR TITLE
Upgrade Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         goarch: ["386", amd64]
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@feature/compression
+    - uses: wangyoucao577/go-release-action@v1.0.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         goarch: ["386", amd64]
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.0.1
+    - uses: wangyoucao577/go-release-action@feature/compression
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}


### PR DESCRIPTION
The latest release action:    
- Fixed GOOS/GOARCH set error
- Use .zip instead of .tar.gz on windows

Refer to https://github.com/wangyoucao577/go-release-action/releases/tag/v1.0.2 for more details. 