### PR TITLE
Improve Release Binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
       matrix:
         goos: [linux, windows, darwin]
         goarch: ["386", amd64]
+        exclude:  
+          # windows/386 and darwin/386 seems useless 
+          - goarch: "386"
+            goos: windows 
+          - goarch: "386"
+            goos: darwin 
     steps:
     - uses: actions/checkout@v2
     - uses: wangyoucao577/go-release-action@feature/musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         goarch: ["386", amd64]
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.0.2
+    - uses: wangyoucao577/go-release-action@feature/musl
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             goos: darwin 
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@feature/musl
+    - uses: wangyoucao577/go-release-action@v1.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}


### PR DESCRIPTION
- Fix `musl` dependency on `linux/amd64`.    
- Remove `windows/386` and `darwin/386` binaries, these two seem useless.    